### PR TITLE
AB#62: Add organization information for communication with front end

### DIFF
--- a/src/main/java/com/psu/devboards/dbapi/controllers/UserController.java
+++ b/src/main/java/com/psu/devboards/dbapi/controllers/UserController.java
@@ -1,12 +1,14 @@
 package com.psu.devboards.dbapi.controllers;
 
 import com.psu.devboards.dbapi.models.entities.User;
+import com.psu.devboards.dbapi.models.entities.Organization;
 import com.psu.devboards.dbapi.services.UserService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
+import java.util.Set;
 
 @RestController
 @RequestMapping("users")
@@ -18,7 +20,13 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    public User getMe(Principal principal) {
+    public User getCurrentUser(Principal principal) {
         return userService.getByUserName(principal.getName());
+    }
+
+    @GetMapping("/me/organizations")
+    public Set<Organization> getCurrentUserOrganizations(Principal principal){
+        User user = userService.getByUserName(principal.getName());
+        return user.getOwnedOrganizations();
     }
 }

--- a/src/test/java/com/psu/devboards/dbapi/controllers/UserControllerTestIT.java
+++ b/src/test/java/com/psu/devboards/dbapi/controllers/UserControllerTestIT.java
@@ -33,4 +33,15 @@ class UserControllerTestIT {
     void shouldReturnUnauthorizedWhenNoUser() throws Exception {
         mockMvc.perform(get("/users/me")).andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @WithMockUser(username = "testUser")
+    void shouldReturnOkWhenAuthorizedOrg() throws Exception {
+        mockMvc.perform(get("/users/me/organizations")).andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenNoUserOrg() throws Exception {
+        mockMvc.perform(get("/users/me/organizations")).andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
This is mostly so we can detect if a user is currently in or owns any organizations. This allows prompting the creation of one on the front end if one does not exist.