### PR TITLE
Allow Content-Type header required to POST organization creation

### DIFF
--- a/src/main/java/com/psu/devboards/dbapi/configs/SecurityConfig.java
+++ b/src/main/java/com/psu/devboards/dbapi/configs/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
-        configuration.setAllowedHeaders(Collections.singletonList("Authorization"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;


### PR DESCRIPTION
Received CORS error when trying to POST name JSON information for creating an organization to /organization.
This appears to fix that.